### PR TITLE
Link spectertest2 repo from GitHub dashboard

### DIFF
--- a/github/index.html
+++ b/github/index.html
@@ -45,7 +45,7 @@
             <li><a href="repo.html">jss-oai/jss-oai.github.io</a></li>
             <li><a href="#">openai/topiary-intern</a></li>
             <li><a href="#">jss-oai/coding-project</a></li>
-            <li><a href="#">hollyblue296/spectertest2</a></li>
+            <li><a href="repo.html">hollyblue296/spectertest2</a></li>
             <li><a href="#">hollyblue296/spectertest</a></li>
             <li><a href="#">hollyblue296/open-ml</a></li>
             <li><a href="#">openai/prompt-injection-defense</a></li>


### PR DESCRIPTION
## Summary
- Route `hollyblue296/spectertest2` in GitHub-style dashboard to the repository page.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_i_689c0ccc1e448329a2ac859592900ab1